### PR TITLE
Fix incompatibility with Pigeonhole 0.5.9 and newer

### DIFF
--- a/src/ext-extdata-common.c
+++ b/src/ext-extdata-common.c
@@ -32,7 +32,7 @@ bool ext_extdata_load(const struct sieve_extension *ext, void **context)
 
 	dict_uri = sieve_setting_get(ext->svinst, "sieve_extdata_dict_uri");
 	if ( dict_uri == NULL ) {
-		sieve_sys_warning(ext->svinst, 
+		e_warning(ext->svinst->event,
 			"extdata: no dict uri specified, extension is unconfigured "
 			"(sieve_extdata_dict_uri is not set).");
 	}

--- a/src/sieve-extdata-plugin.c
+++ b/src/sieve-extdata-plugin.c
@@ -28,7 +28,7 @@ void sieve_extdata_plugin_load
 		(svinst, &extdata_extension, FALSE);
 
 	if ( svinst->debug ) {
-		sieve_sys_debug(svinst, "%s version %s loaded",
+		e_debug(svinst->event, "%s version %s loaded",
 			SIEVE_EXTDATA_NAME, SIEVE_EXTDATA_VERSION);
 	}
 


### PR DESCRIPTION
The extdata plugin does not work with Pigeonhole 0.5.9 and newer due to the change in commit f73ce51d2c0046e52367a426f7de1c9e21c72297 that removed the sieve_sys_* functions. The calls to those functions have been replaced with calls to e_debug and e_warning, which should make the plugin work again under 0.5.9 and later (tested with CentOS binary packages of Dovecot 2.3.11.3).

As we're apparantly one of the only users of this plugin (and it has never moved beyond the experimental status) we'll be moving to a solution based on the extprograms plugin somewhere in the coming months; however, this fix may still be of use to somebody.

(Also, many thanks for your Sieve implementation. You make some customers of ours very happy!)